### PR TITLE
Add missing `dnstoresolve` to module arguments

### DIFF
--- a/nodeping.py
+++ b/nodeping.py
@@ -681,6 +681,7 @@ def run_module():
         checktoken=dict(type='str', required=False),
         contentstring=dict(type='str', required=False),
         dnstype=dict(type='str', required=False),
+        dnstoresolve=dict(type='str', required=False),
         dnsrd=dict(type='bool', required=False, default=True),
         transport=dict(type='str', required=False,
                        default='udp', choices=['udp', 'tcp']),


### PR DESCRIPTION
This is available in the documentation, but fails if used in an Ansible task.